### PR TITLE
Add build script for binary distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,12 @@ Activate the environment with:
 source venv/bin/activate
 ```
 
+
+## Build
+Run `./build.sh` to create a standalone binary using PyInstaller. The script reuses the virtual environment created by `install.sh` or creates one if needed.
+
+The resulting executable is placed in the `build/` directory. Execute it with:
+
+```bash
+./build/url-to-llm-friendly-md
+```

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+
+# Ensure python venv support exists
+if ! python -m venv -h >/dev/null 2>&1; then
+  echo "Python virtual environment support not found." >&2
+  echo "Please install the python3-venv package and rerun this script." >&2
+  exit 1
+fi
+
+# Create venv if it doesn't exist
+if [ ! -d "venv" ]; then
+  python -m venv venv
+fi
+
+# shellcheck source=/dev/null
+. venv/bin/activate
+python -m pip install --upgrade pip
+pip install --upgrade pyinstaller
+
+# Build the binary
+pyinstaller --onefile src/cli.py -n url-to-llm-friendly-md
+
+# Move binary to build directory
+mkdir -p build
+mv -f dist/url-to-llm-friendly-md build/
+
+printf '\nBinary available at build/url-to-llm-friendly-md\n'


### PR DESCRIPTION
## Summary
- add `build.sh` for creating a PyInstaller binary
- explain the build process in the README

## Testing
- `bash -n build.sh`


------
https://chatgpt.com/codex/tasks/task_e_6853980966988327abc4693b7d8b5eea