### PR TITLE
Add install script and packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # url-to-llm-friendly-markdown
-Use this cli to quickly grab a url and output an LLM friendly markdown file. Utilises m92vyas/llm-reader lib.
+
+This repository provides a simple command line interface that wraps the
+[m92vyas/llm-reader](https://github.com/m92vyas/llm-reader) library.  
+Use it to fetch a webpage and output the processed, LLM-friendly markdown.
+
+## Installation
+
+Run the bundled script to install this project and its dependency
+[`llm-reader`](https://github.com/m92vyas/llm-reader):
+
+```bash
+./install.sh
+```
+
+This will install a `url-to-llm` command on your system.
+
+The CLI relies on Google Chrome and the matching ChromeDriver binary. Make sure
+both are installed and on your `PATH` before running.
+
+## Usage
+
+```bash
+url-to-llm https://example.com -o page.md
+```
+
+Run `url-to-llm --help` for available options.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+python -m pip install --upgrade pip
+pip install git+https://github.com/m92vyas/llm-reader
+pip install .

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup
+
+setup(
+    name='url-to-llm-friendly-markdown',
+    version='0.1.0',
+    py_modules=['cli'],
+    package_dir={'': 'src'},
+    install_requires=[
+        'llm-reader @ git+https://github.com/m92vyas/llm-reader',
+    ],
+    entry_points={
+        'console_scripts': [
+            'url-to-llm=cli:main',
+        ],
+    },
+)

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,69 @@
+import argparse
+import asyncio
+from url_to_llm_text.get_html_text import get_page_source
+from url_to_llm_text.get_llm_input_text import get_processed_text
+
+async def run(args: argparse.Namespace) -> None:
+    try:
+        page_source = await get_page_source(
+            args.url,
+            wait=args.wait,
+            headless=not args.no_headless,
+        )
+    except Exception as e:
+        raise SystemExit(
+            f"Error while fetching page: {e}. "
+            "Ensure Chrome and the matching driver are installed."
+        )
+    if not page_source:
+        raise SystemExit(
+            "Failed to fetch the page. Ensure Chrome and ChromeDriver are installed."
+        )
+    processed = await get_processed_text(
+        page_source,
+        args.url,
+        keep_images=not args.no_images,
+        keep_webpage_links=not args.no_links,
+    )
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(processed)
+    else:
+        print(processed)
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fetch URL content and output LLM-friendly markdown",
+    )
+    parser.add_argument("url", help="URL to fetch")
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Write output to file instead of stdout",
+    )
+    parser.add_argument(
+        "--wait",
+        type=float,
+        default=1.5,
+        help="Seconds to wait for the page to load (default: 1.5)",
+    )
+    parser.add_argument(
+        "--no-headless",
+        action="store_true",
+        help="Disable headless browser mode",
+    )
+    parser.add_argument(
+        "--no-images",
+        action="store_true",
+        help="Remove images from the output",
+    )
+    parser.add_argument(
+        "--no-links",
+        action="store_true",
+        help="Remove webpage links from the output",
+    )
+    args = parser.parse_args()
+    asyncio.run(run(args))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `install.sh` script to install dependencies and package
- document installation and usage in README
- provide `setup.py` for editable/CLI installation
- handle missing Chrome driver gracefully
- note Chrome requirement in README

## Testing
- `python -m py_compile src/cli.py`
- `url-to-llm --help | head -n 20`
- `pip install -e .`


------
https://chatgpt.com/codex/tasks/task_e_68536e8034348327823e623b958cc657